### PR TITLE
Revert changes to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@
 title: "CMS VOICES"
 description: "Homepage of @CMSvoices from the CMS Experiment at CERN."
 analytics: #Google analytics code in the format XX-nnnnnnnn-n
-baseurl: "" #important: start with /
+baseurl: "/cms-voices" #important: start with /
 url: "http://cern.ch/cms-voices"
 
 # Build settings


### PR DESCRIPTION
For some reason, the modified `_config.yml` file didn't build `_site` correctly. :/ Reverted to previous version.

Signed-off-by: Achintya Rao <achintya.rao@cern.ch>